### PR TITLE
Added a vim-modeline for the config example

### DIFF
--- a/data/doc/feed2imap/examples/feed2imaprc
+++ b/data/doc/feed2imap/examples/feed2imaprc
@@ -67,3 +67,5 @@ feeds:
 #   - name: test2
 #     target: [ *target, 'test2' ]
 #     ...
+
+# vim: ft=yaml:sts=2:expandtab


### PR DESCRIPTION
This sets the correct modes for vim when editing the configfile. This is
especially needed, as YAML uses indentation for structures.

Options set:
- filetype to YAML (else 'conf' is infered)
- set the number of spaces a tab is to 2
- expandtab -- do not insert \t but spaces
