### PR TITLE
Replace RMail by Mail

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,6 +49,7 @@ begin
 		s.name = PKG_NAME
 		s.version = PKG_VERSION
 		s.add_runtime_dependency 'ruby-feedparser', '>= 0.9'
+		s.add_runtime_dependency 'mail', '>= 2.5'
 		s.require_path = 'lib'
 		s.executables = PKG_FILES.grep(%r{\Abin\/.}).map { |bin|
 		  bin.gsub(%r{\Abin/}, '')

--- a/feed2imap-test
+++ b/feed2imap-test
@@ -47,7 +47,7 @@ File.open(config, 'w') do |f|
   f.write(config_data)
 end
 
-unless system('ruby', "-I#{base}/lib", "#{base}/bin/feed2imap", '--config', config, '--verbose')
+unless system('ruby', "-I#{base}/lib", "#{base}/bin/feed2imap", '--config', config, '--debug')
   puts("E: feed2imap failed")
   exit(1)
 end

--- a/lib/feed2imap/itemtomail.rb
+++ b/lib/feed2imap/itemtomail.rb
@@ -96,10 +96,11 @@ def item_to_mail(config, item, id, updated, from = 'Feed2Imap', inline_images = 
   imgs = []
   if inline_images
     cids = []
+    fetcher = HTTPFetcher::new
     htmlpart.body.gsub!(/(<img[^>]+)src="(\S+?\/([^\/]+?\.(png|gif|jpe?g)))"([^>]*>)/i) do |match|
       # $2 contains url, $3 the image name, $4 the image extension
       begin
-        image = Base64.encode64(HTTPFetcher::fetch($2, Time.at(0)).chomp) + "\n"
+        image = Base64.encode64(fetcher.fetch($2, Time.at(0)).chomp) + "\n"
         cid = "#{Digest::MD5.hexdigest($2)}@#{config.hostname}"
         if not cids.include?(cid)
           cids << cid


### PR DESCRIPTION
RMail got removed from Gentoo because it does not play well with Ruby1.9 (I just believe this fact without further checking). Therefore I replaced the mail-handling library by [Mail](https://github.com/mikel/mail) -- this also comes with the advantage that Mail does a lot more by itself and therefore reduces the mail-handling code in feed2imap.

I checked the new code with mail-2.5, as mail-2.6 is broken in Gentoo. But from the Changelog (and from the fact, that I developed against the 2.6 documentation) it should also work with mail-2.6

With commit 84d3a60 I also fix the use of HTTPFetcher -- as it turns out include_images was broken for some time without anybody noticing :)

**NB**: I'm not a Ruby programmer, so please inspect my code for it may not be in Ruby style.