### PR TITLE
Increased REXML entity expansion limit for large feed items.

### DIFF
--- a/bin/feed2imap
+++ b/bin/feed2imap
@@ -2,6 +2,9 @@
 
 $:.unshift File.join(File.dirname(__FILE__), '..', 'lib')
 
+require 'rexml/document'
+REXML::Document.entity_expansion_text_limit=102400
+
 require 'feed2imap/feed2imap'
 require 'optparse'
 


### PR DESCRIPTION
Fixes #10. Probably this value should be configurable.